### PR TITLE
Do not use columns for cleaner help output on MacOS

### DIFF
--- a/subcommander
+++ b/subcommander
@@ -42,7 +42,7 @@ subcommander() {
 warn() {
 	>&2 printf '\e[1;33m%s\e[0m\n' "$*"
 }
-if type column > /dev/null; then
+if type column > /dev/null && [ "$(uname)" != 'Darwin' ]; then
 	alias draw_subcommand_table="sort -s -k 1,1 | column -s'\`' -o' | ' -t -N SUBCOMMAND,ALIASES,DESCRIPTION -R SUBCOMMAND"
 else
 	alias draw_subcommand_table="sort -s -k 1,1"
@@ -110,7 +110,7 @@ $name\`$aliases\`$description"
 			addAliasToOutput "$realsubcmd" \
 				"$(basename "$subcmd")" \
 				"$desc"
-				
+
 		elif [ -f "$subcmd" ] && ! echo "$out" | grep -E "^$(basename "$subcmd")\`" >/dev/null 2>&1; then
 			addToOutput "$(basename "$subcmd")" "" "$(extract_from_script 'Description' "$subcmd")"
 		elif [ -d "$subcmd" ] && [ ! -f "$linkednsd/$(basename "$subcmd")" ] ; then
@@ -130,7 +130,7 @@ extract_from_script() {
 }
 
 scope_to_subcommand() {
-	echo "$1" | sed -e "s@$SUBCOMMANDS/@@" -e 's@/@ @g' -e 's@/$@@' 
+	echo "$1" | sed -e "s@$SUBCOMMANDS/@@" -e 's@/@ @g' -e 's@/$@@'
 }
 
 dir_to_usage() {


### PR DESCRIPTION
The current usage of columns takes advantage of switches not available on OSX.